### PR TITLE
Automate Build Process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -347,4 +347,4 @@ MigrationBackup/
 .idea/
 
 # Dependencies
-/src/libs
+/game

--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Dependencies
 /game
+discord_game_sdk.dll

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ If you are on BepInEx 5.3 or prior, not all of the DLL files can be put in the p
 To uninstall, you only need to delete the `BepInEx\plugins\H3MP` directory. `discord_game_sdk.dll` will not be loaded if H3MP is not present, just like how BepInEx is not loaded if `winhttp.dll` is not present.
 
 ## Building
+:warning: All scripts listed here must be ran the root git directory (has the scripts directory in it). **Do not run a script by double clicking on it, or with the current directory set to `scripts`**. :warning:
+
 ### Get the Dependencies
 #### 1. Download the [Discord GameSDK](https://discord.com/developers/docs/game-sdk/sdk-starter-guide#step-1-get-the-thing) and extract `lib/x86_64/discord_game_sdk.dll` to `src/H3MP/Discord/`
 This can be done using `scripts/get_discord_gamesdk.sh`.  

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ A **WIP** multiplayer mod for Hot Dogs, Horseshoes, and Hand Grenades.
 
 ## Installation
 1. Have [Discord](https://discord.com/download) installed and running. Discord Rich Presence is the only way to join or invite other players.  
-2. Download the [most recent x64 release of BepInEx](https://github.com/BepInEx/BepInEx/releases/latest) and extract it to your H3VR root directory.
-3. Download the [most recent release of H3MP](https://github.com/ash-hat/H3MP/releases/latest) and extract it to your H3VR root directory.  
+2. Download the [most recent x64 release of BepInEx](https://github.com/BepInEx/BepInEx/releases/latest) and extract it to your H3VR directory.
+3. Download the [most recent release of H3MP](https://github.com/ash-hat/H3MP/releases/latest) and extract it to your H3VR directory.  
 4. Start the game  
     - Join a party by clicking the "Join" button on a Discord invite. In the future, you can join off of invites and the game will start automatically.
     - Invite players to your party by clicking the plus button in a Discord text channel, and select "Invite ... to Play H3MP".
@@ -32,14 +32,24 @@ If you are on BepInEx 5.3 or prior, not all of the DLL files can be put in the p
 To uninstall, you only need to delete the `BepInEx\plugins\H3MP` directory. `discord_game_sdk.dll` will not be loaded if H3MP is not present, just like how BepInEx is not loaded if `winhttp.dll` is not present.
 
 ## Building
-1. Copy or symlink the required dependencies from `h3vr_Data\Managed\` to `src\libs\`  
-    - `AssemblyCSharp.dll`  
-    - `UnityEngine.dll`  
-2. Copy or symlink the required dependencies from `BepInEx\core\` to `src\libs\`  
-    - `0Harmony.dll`  
-    - `BepInEx.dll`  
-3. Build the solution  
-    a. This project makes use of NuGet packages. If your IDE does not automatically restore NuGet packages, make sure to restore them manually.
+### Get the Dependencies
+#### 1. Download the [Discord GameSDK](https://discord.com/developers/docs/game-sdk/sdk-starter-guide#step-1-get-the-thing) and extract `lib/x86_64/discord_game_sdk.dll` to `src/H3MP/Discord/`
+This can be done using `scripts/get_discord_gamesdk.sh`.  
+This script is compatible with any environment, given that POSIX compliant `curl`, `unzip`, and `rm` commands are present. This includes and has been tested against Git Bash for Windows.
+
+#### 2. Create a symlink named `game` that points to the H3VR directory. 
+- Windows: `scripts/link_game.bat` does this for you. If it cannot find the game itself, it will ask for input.  
+- POSIX platforms: `ln -s <H3VR directory> game`
+
+#### 3. Restore NuGet packages
+Most IDEs automatically do this, but if you do not have such an IDE, run `nuget restore`.
+
+### Build the Source Code
+#### 1. Build the `H3MP` project
+Or the entire solution, they do the same thing. Your choice.
+
+#### 2. (Windows only) Consider symlinking the `Debug` builds
+If you are planning on debugging your build, it is tedious to keep selecting, copying, and pasting the same 3 files over and over again. For this reason, you can run `scripts/link_builds.bat`. It will symlink your `Debug` builds back over to the game so any changes in your builds is reflected in the game.
 
 # Other Information
 - Target Game: *Hot Dogs, Horseshoes, and Hand Grenades* ([Website](http://h3vr.com/); [Steam](https://store.steampowered.com/app/450540/Hot_Dogs_Horseshoes__Hand_Grenades/))  

--- a/scripts/get_discord_gamesdk.sh
+++ b/scripts/get_discord_gamesdk.sh
@@ -1,0 +1,7 @@
+VERSION="2.5.6"
+FILE="discord_game_sdk.zip"
+URL="https://dl-game-sdk.discordapp.net/$VERSION/$FILE"
+
+curl -o "$FILE" "$URL"
+unzip -j "$FILE" "lib/x86_64/discord_game_sdk.dll" -d "src/H3MP/Discord/"
+rm "$FILE"

--- a/scripts/link_builds.bat
+++ b/scripts/link_builds.bat
@@ -1,0 +1,97 @@
+:: Creates a symlink linking game plugin binaries the built plugin binaries for an easy debugging setup.
+
+@echo off
+setlocal EnableDelayedExpansion
+
+set "H3MP_DEFAULT_H3VR_PATH=C:\Program Files (x86)\Steam\steamapps\common\H3VR"
+set "H3MP_BINS=discord_game_sdk.dll H3MP.dll H3MP.Networking.dll LiteNetLib.dll"
+
+if exist "%H3MP_DEFAULT_H3VR_PATH%" (
+    echo Found the game at the default path: "%H3MP_DEFAULT_H3VR_PATH%"
+    set "H3MP_H3VR_PATH=%H3MP_DEFAULT_H3VR_PATH%"
+) else (
+    echo Could not find H3VR in the default Steam library path.
+    echo.
+    echo You must specify the path of one of your choosing:
+
+    :user_path_menu
+    echo 1 ^) Steam library that houses H3VR
+    echo 2 ^) Path to H3VR's root directory
+    echo.
+    set /p "H3MP_MODE=Option (default 1): " || set "H3MP_MODE=1"
+
+    if not "!H3MP_MODE!" == "1" if not "!H3MP_MODE!" == "2" (
+        echo "!H3MP_MODE!"
+        echo Invalid option
+        goto user_path_menu
+    )
+
+    :user_path_menu_success
+    set /p H3MP_PATH=Path ^(no quotes or trailing backslash^): 
+
+    if "!H3MP_MODE!" == "1" (
+        set "H3MP_H3VR_PATH=!H3MP_PATH!\steamapps\common\H3VR"
+    ) else if "!H3MP_MODE!" == "2" (
+        set "H3MP_H3VR_PATH=!H3MP_PATH!"
+    )
+    
+    if not exist "!H3MP_H3VR_PATH!" (
+        echo Path not found: "!H3MP_H3VR_PATH!"
+        goto user_path_menu
+    )
+
+    echo Set game path to: "!H3MP_H3VR_PATH!"
+)
+
+echo.
+
+if exist "%H3MP_H3VR_PATH%\h3vr.exe" if exist "%H3MP_H3VR_PATH%\h3vr_Data" (
+    goto is_h3vr_true
+)
+    echo The target path does not match H3VR's directory structure.
+    echo.
+    goto user_path_menu
+:is_h3vr_true
+
+if not exist "%H3MP_H3VR_PATH%\BepInEx\plugins" (
+    echo BepInEx, needed to run H3MP, doesn't seem to be installed.
+    exit /b 2
+)
+
+set "H3MP_PLUGIN=%H3MP_H3VR_PATH%\BepInEx\plugins\H3MP"
+if not exist "%H3MP_PLUGIN%" (
+    mkdir "%H3MP_PLUGIN%"
+)
+
+for %%f in (%H3MP_BINS%) do (
+    set "H3MP_LINK=%H3MP_PLUGIN%\%%f"
+
+    if exist "!H3MP_LINK!" (
+        echo A binary already exists. This script will not overwrite it. Please move, rename, or delete it.
+        echo Path: "!H3MP_LINK!"
+
+        exit /b 3
+    )
+)
+
+:mklink_calls
+for %%f in (%H3MP_BINS%) do (
+    set "H3MP_LINK=%H3MP_PLUGIN%\%%f"
+    mklink "!H3MP_LINK!" "src\H3MP\bin\Debug\%%f"
+
+    if not exist "!H3MP_LINK!" if not %errorLevel% == 0 (
+        net session >nul 2>&1
+        if not %errorLevel% == 0 (
+            echo.
+            echo Detected a failed mklink call in a user session.
+            echo If you are on Windows 10 Creators ^(1703^) or later, you can enable developer mode.
+            echo If you are not, run this file as administrator.
+            echo.
+            echo You can retry the mklink calls ^(after you enable developer mode^) by pressing any key. Ctrl-C to quit.
+
+            pause >nul
+            echo.
+            goto mklink_calls
+        )
+    )
+)

--- a/scripts/link_game.bat
+++ b/scripts/link_game.bat
@@ -1,0 +1,69 @@
+:: Creates a symlink linking the game's directory to a local directory for easy and atomic dependency setup.
+
+@echo off
+setlocal EnableDelayedExpansion
+
+set "H3MP_LINK_PATH=game"
+
+if exist "%H3MP_LINK_PATH%" (
+    echo A path already exists at %H3MP_LINK_PATH%. If this does not lead to the desired target, delete it and rerun this script.
+    exit /b 1
+)
+
+set "H3MP_DEFAULT_TARGET_PATH=C:\Program Files (x86)\Steam\steamapps\common\H3VR"
+
+if exist "%H3MP_DEFAULT_H3VR_PATH%" (
+    echo Found the game at the default path: "%H3MP_DEFAULT_H3VR_PATH%"
+    set "H3MP_H3VR_PATH=%H3MP_DEFAULT_H3VR_PATH%"
+) else (
+    echo Could not find H3VR in the default Steam library path.
+    echo.
+    echo You must specify the path of one of your choosing:
+
+    :user_path_menu
+    echo 1 ^) Steam library that houses H3VR
+    echo 2 ^) Path to H3VR's root directory
+    echo.
+    set /p "H3MP_MODE=Option (default 1): " || set "H3MP_MODE=1"
+
+    if not "!H3MP_MODE!" == "1" if not "!H3MP_MODE!" == "2" (
+        echo "!H3MP_MODE!"
+        echo Invalid option
+        goto user_path_menu
+    )
+
+    :user_path_menu_success
+    set /p H3MP_PATH=Path ^(no quotes or trailing backslash^): 
+
+    if "!H3MP_MODE!" == "1" (
+        set "H3MP_H3VR_PATH=!H3MP_PATH!\steamapps\common\H3VR"
+    ) else if "!H3MP_MODE!" == "2" (
+        set "H3MP_H3VR_PATH=!H3MP_PATH!"
+    )
+    
+    if not exist "!H3MP_H3VR_PATH!" (
+        echo Path not found: "!H3MP_H3VR_PATH!"
+        goto user_path_menu
+    )
+
+    echo Set game path to: "!H3MP_H3VR_PATH!"
+)
+
+echo.
+
+if exist "%H3MP_H3VR_PATH%\h3vr.exe" if exist "%H3MP_H3VR_PATH%\h3vr_Data\Managed" (
+    goto is_h3vr_true
+)
+    echo The target path does not match H3VR's directory structure.
+    echo.
+    goto user_path_menu
+:is_h3vr_true
+
+if not exist "%H3MP_H3VR_PATH%\BepInEx\core" (
+    echo BepInEx, needed to build H3MP, doesn't seem to be installed. 
+    echo If you would like to build H3MP without running BepInEx, you can delete the its hook, "winhttp.dll", after installing it.
+    exit /b 2
+)
+
+:: Does not require elevated permissions
+mklink /j "%H3MP_LINK_PATH%" "%H3MP_H3VR_PATH%"

--- a/src/H3MP.Networking/H3MP.Networking.csproj
+++ b/src/H3MP.Networking/H3MP.Networking.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BepInEx">
-      <HintPath>..\libs\BepInEx.dll</HintPath>
+      <HintPath>..\..\game\BepInEx\core\BepInEx.dll</HintPath>
     </Reference>
     <Reference Include="LiteNetLib, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\LiteNetLib.0.9.3.2\lib\net35\LiteNetLib.dll</HintPath>

--- a/src/H3MP/H3MP.csproj
+++ b/src/H3MP/H3MP.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -112,6 +112,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Discord\discord_game_sdk.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\H3MP.Networking\H3MP.Networking.csproj">

--- a/src/H3MP/H3MP.csproj
+++ b/src/H3MP/H3MP.csproj
@@ -35,20 +35,20 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\libs\0Harmony.dll</HintPath>
+      <HintPath>..\game\BepInEx\core\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\libs\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\game\h3vr_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx">
-      <HintPath>..\libs\BepInEx.dll</HintPath>
+      <HintPath>..\..\game\BepInEx\core\BepInEx.dll</HintPath>
     </Reference>
     <Reference Include="LiteNetLib, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\LiteNetLib.0.9.3.2\lib\net35\LiteNetLib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="UnityEngine">
-      <HintPath>..\libs\UnityEngine.dll</HintPath>
+      <HintPath>..\..\game\h3vr_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/H3MP/H3MP.csproj
+++ b/src/H3MP/H3MP.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\game\BepInEx\core\0Harmony.dll</HintPath>
+      <HintPath>..\..\game\BepInEx\core\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
       <HintPath>..\..\game\h3vr_Data\Managed\Assembly-CSharp.dll</HintPath>


### PR DESCRIPTION
The old build process required finding, copying, even downloading and extracting with Discord GameSDK dependencies, by hand. Then to debug, the build results had to be copied over. Once again, by hand.

This PR intends to automate the build and local debugging process after first-time-setup scripts are run. The readme has been expanded upon to explain the requires dependency structure, along with more detailed build instructions.